### PR TITLE
feat: add extended runtime support for background breathing sessions

### DIFF
--- a/Ovlo.xcodeproj/project.pbxproj
+++ b/Ovlo.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		68EC6D302EFC0001009E99EE /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 68EC6D2F2EFC0001009E99EE /* LaunchScreen.storyboard */; };
 		68EC6CD62ED4B7D7009E99EE /* SessionControlViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68EC6CCF2ED4B7D7009E99EE /* SessionControlViewModel.swift */; };
 		68EC6CD72ED4B7D7009E99EE /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68EC6CD12ED4B7D7009E99EE /* ContentView.swift */; };
 		68EC6CD82ED4B7D7009E99EE /* OvloApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68EC6CD42ED4B7D7009E99EE /* OvloApp.swift */; };
@@ -32,8 +31,12 @@
 		68EC6D212ED4C000009E99EE /* WatchConnectivityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68EC6D092ED4B83B009E99EE /* WatchConnectivityTests.swift */; };
 		68EC6D222ED4C000009E99EE /* MockWatchConnectivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68EC6CFF2ED4B83B009E99EE /* MockWatchConnectivity.swift */; };
 		68EC6D232ED4C000009E99EE /* TestClock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68EC6D002ED4B83B009E99EE /* TestClock.swift */; };
+		68EC6D302EFC0001009E99EE /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 68EC6D2F2EFC0001009E99EE /* LaunchScreen.storyboard */; };
 		68EC6D402ED5A000009E99EE /* BreathingViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68EC6D412ED5A000009E99EE /* BreathingViewModelTests.swift */; };
 		68EC6D422ED5A000009E99EE /* UserJourneyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68EC6D432ED5A000009E99EE /* UserJourneyTests.swift */; };
+		68EC6D502EFC1001009E99EE /* ExtendedRuntimeController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68EC6D512EFC1001009E99EE /* ExtendedRuntimeController.swift */; };
+		68EC6D522EFC1001009E99EE /* ExtendedRuntimeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68EC6D532EFC1001009E99EE /* ExtendedRuntimeTests.swift */; };
+		68F00AD02ED8BC5800243E08 /* OvloWatch.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = 68F00ACE2ED8BBFE00243E08 /* OvloWatch.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -51,6 +54,13 @@
 			remoteGlobalIDString = 68A7D7792ED4B08F0013DB96;
 			remoteInfo = OvloWatch;
 		};
+		68F00AD12ED8BC5800243E08 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 68A7D7652ED4B08E0013DB96 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 68A7D7792ED4B08F0013DB96;
+			remoteInfo = OvloWatch;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -60,6 +70,7 @@
 			dstPath = "$(CONTENTS_FOLDER_PATH)/Watch";
 			dstSubfolderSpec = 16;
 			files = (
+				68F00AD02ED8BC5800243E08 /* OvloWatch.app in Embed Watch Content */,
 			);
 			name = "Embed Watch Content";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -67,8 +78,6 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		68A7D76D2ED4B08F0013DB96 /* OvloPhone.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; name = OvloPhone.app; path = "/Users/edd/Projects/Ovlo/Ovlo/build/Debug-iphoneos/OvloPhone.app"; sourceTree = "<absolute>"; };
-		68A7D77A2ED4B08F0013DB96 /* OvloWatch.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; name = OvloWatch.app; path = "/Users/edd/Projects/Ovlo/Ovlo/build/Debug-watchos/OvloWatch.app"; sourceTree = "<absolute>"; };
 		68EC6CCF2ED4B7D7009E99EE /* SessionControlViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionControlViewModel.swift; sourceTree = "<group>"; };
 		68EC6CD12ED4B7D7009E99EE /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		68EC6CD32ED4B7D7009E99EE /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -90,10 +99,16 @@
 		68EC6D082ED4B83B009E99EE /* BreathingEngineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BreathingEngineTests.swift; sourceTree = "<group>"; };
 		68EC6D092ED4B83B009E99EE /* WatchConnectivityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchConnectivityTests.swift; sourceTree = "<group>"; };
 		68EC6D0B2ED4BBFE009E99EE /* StartView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartView.swift; sourceTree = "<group>"; };
-		68EC6D412ED5A000009E99EE /* BreathingViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BreathingViewModelTests.swift; sourceTree = "<group>"; };
-		68EC6D432ED5A000009E99EE /* UserJourneyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserJourneyTests.swift; sourceTree = "<group>"; };
 		68EC6D0E2ED4C000009E99EE /* OvloWatchTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OvloWatchTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		68EC6D2F2EFC0001009E99EE /* LaunchScreen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
+		68EC6D412ED5A000009E99EE /* BreathingViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BreathingViewModelTests.swift; sourceTree = "<group>"; };
+		68EC6D432ED5A000009E99EE /* UserJourneyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserJourneyTests.swift; sourceTree = "<group>"; };
+		68EC6D512EFC1001009E99EE /* ExtendedRuntimeController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtendedRuntimeController.swift; sourceTree = "<group>"; };
+		68EC6D532EFC1001009E99EE /* ExtendedRuntimeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtendedRuntimeTests.swift; sourceTree = "<group>"; };
+		68F00ACD2ED8BBFE00243E08 /* OvloPhone.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = OvloPhone.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		68F00ACE2ED8BBFE00243E08 /* OvloWatch.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = OvloWatch.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		68F00AD32ED8BCAB00243E08 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		68F00AD42ED8BCF100243E08 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -129,6 +144,9 @@
 				68EC6CE82ED4B7F2009E99EE /* OvloWatch */,
 				68EC6D0A2ED4B83B009E99EE /* OvloWatchTests */,
 				68EC6D0E2ED4C000009E99EE /* OvloWatchTests.xctest */,
+				68F00ACD2ED8BBFE00243E08 /* OvloPhone.app */,
+				68F00ACE2ED8BBFE00243E08 /* OvloWatch.app */,
+				68F00ACF2ED8BC5800243E08 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -151,6 +169,7 @@
 		68EC6CD52ED4B7D7009E99EE /* OvloPhone */ = {
 			isa = PBXGroup;
 			children = (
+				68F00AD42ED8BCF100243E08 /* Info.plist */,
 				68EC6CD02ED4B7D7009E99EE /* ViewModels */,
 				68EC6CD22ED4B7D7009E99EE /* Views */,
 				68EC6CD32ED4B7D7009E99EE /* Assets.xcassets */,
@@ -166,6 +185,7 @@
 				68EC6CDA2ED4B7F2009E99EE /* BreathingEngine.swift */,
 				68EC6CDB2ED4B7F2009E99EE /* BreathingState.swift */,
 				68EC6CDC2ED4B7F2009E99EE /* ClockProtocol.swift */,
+				68EC6D512EFC1001009E99EE /* ExtendedRuntimeController.swift */,
 				68EC6CDD2ED4B7F2009E99EE /* HapticController.swift */,
 			);
 			path = Domain;
@@ -200,6 +220,7 @@
 		68EC6CE82ED4B7F2009E99EE /* OvloWatch */ = {
 			isa = PBXGroup;
 			children = (
+				68F00AD32ED8BCAB00243E08 /* Info.plist */,
 				68EC6CDE2ED4B7F2009E99EE /* Domain */,
 				68EC6CE02ED4B7F2009E99EE /* ViewModels */,
 				68EC6CE52ED4B7F2009E99EE /* Views */,
@@ -250,10 +271,18 @@
 				68EC6D012ED4B83B009E99EE /* Mocks */,
 				68EC6D082ED4B83B009E99EE /* BreathingEngineTests.swift */,
 				68EC6D412ED5A000009E99EE /* BreathingViewModelTests.swift */,
+				68EC6D532EFC1001009E99EE /* ExtendedRuntimeTests.swift */,
 				68EC6D432ED5A000009E99EE /* UserJourneyTests.swift */,
 				68EC6D092ED4B83B009E99EE /* WatchConnectivityTests.swift */,
 			);
 			path = OvloWatchTests;
+			sourceTree = "<group>";
+		};
+		68F00ACF2ED8BC5800243E08 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -272,12 +301,13 @@
 			);
 			dependencies = (
 				68A7D77D2ED4B08F0013DB96 /* PBXTargetDependency */,
+				68F00AD22ED8BC5800243E08 /* PBXTargetDependency */,
 			);
 			name = OvloPhone;
 			packageProductDependencies = (
 			);
 			productName = OvloPhone;
-			productReference = 68A7D76D2ED4B08F0013DB96 /* OvloPhone.app */;
+			productReference = 68F00ACD2ED8BBFE00243E08 /* OvloPhone.app */;
 			productType = "com.apple.product-type.application";
 		};
 		68A7D7792ED4B08F0013DB96 /* OvloWatch */ = {
@@ -296,7 +326,7 @@
 			packageProductDependencies = (
 			);
 			productName = OvloWatch;
-			productReference = 68A7D77A2ED4B08F0013DB96 /* OvloWatch.app */;
+			productReference = 68F00ACE2ED8BBFE00243E08 /* OvloWatch.app */;
 			productType = "com.apple.product-type.application";
 		};
 		68EC6D0D2ED4C000009E99EE /* OvloWatchTests */ = {
@@ -414,6 +444,7 @@
 				68EC6CEB2ED4B7F2009E99EE /* BreathingViewModel.swift in Sources */,
 				68EC6D0C2ED4BBFE009E99EE /* StartView.swift in Sources */,
 				68EC6CED2ED4B7F2009E99EE /* HapticController.swift in Sources */,
+				68EC6D502EFC1001009E99EE /* ExtendedRuntimeController.swift in Sources */,
 				68EC6CEE2ED4B7F2009E99EE /* BreathingView.swift in Sources */,
 				68EC6CEF2ED4B7F2009E99EE /* BreathingEngine.swift in Sources */,
 				68EC6CF02ED4B7F2009E99EE /* ClockProtocol.swift in Sources */,
@@ -428,6 +459,7 @@
 			files = (
 				68EC6D202ED4C000009E99EE /* BreathingEngineTests.swift in Sources */,
 				68EC6D402ED5A000009E99EE /* BreathingViewModelTests.swift in Sources */,
+				68EC6D522EFC1001009E99EE /* ExtendedRuntimeTests.swift in Sources */,
 				68EC6D422ED5A000009E99EE /* UserJourneyTests.swift in Sources */,
 				68EC6D212ED4C000009E99EE /* WatchConnectivityTests.swift in Sources */,
 				68EC6D222ED4C000009E99EE /* MockWatchConnectivity.swift in Sources */,
@@ -447,6 +479,11 @@
 			isa = PBXTargetDependency;
 			target = 68A7D7792ED4B08F0013DB96 /* OvloWatch */;
 			targetProxy = 68EC6D102ED4C000009E99EE /* PBXContainerItemProxy */;
+		};
+		68F00AD22ED8BC5800243E08 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 68A7D7792ED4B08F0013DB96 /* OvloWatch */;
+			targetProxy = 68F00AD12ED8BC5800243E08 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -577,14 +614,16 @@
 				DEVELOPMENT_TEAM = ANGUD7343N;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = OvloWatch/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = Ovlo;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
+				INFOPLIST_KEY_WKBackgroundModes = "self-care";
 				INFOPLIST_KEY_WKCompanionAppBundleIdentifier = com.eddmann.Ovlo;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.eddmann.Ovlo.watchkitapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -596,7 +635,7 @@
 				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 4;
-				WATCHOS_DEPLOYMENT_TARGET = 26.0;
+				WATCHOS_DEPLOYMENT_TARGET = 11.6;
 			};
 			name = Debug;
 		};
@@ -610,14 +649,16 @@
 				DEVELOPMENT_TEAM = ANGUD7343N;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = OvloWatch/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = Ovlo;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
+				INFOPLIST_KEY_WKBackgroundModes = "self-care";
 				INFOPLIST_KEY_WKCompanionAppBundleIdentifier = com.eddmann.Ovlo;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.eddmann.Ovlo.watchkitapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -630,7 +671,7 @@
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 4;
 				VALIDATE_PRODUCT = YES;
-				WATCHOS_DEPLOYMENT_TARGET = 26.0;
+				WATCHOS_DEPLOYMENT_TARGET = 11.6;
 			};
 			name = Release;
 		};
@@ -644,18 +685,19 @@
 				DEVELOPMENT_TEAM = ANGUD7343N;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = OvloPhone/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = Ovlo;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.eddmann.Ovlo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -679,18 +721,19 @@
 				DEVELOPMENT_TEAM = ANGUD7343N;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = OvloPhone/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = Ovlo;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.eddmann.Ovlo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -724,7 +767,7 @@
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 4;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/OvloWatch.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/OvloWatch";
-				WATCHOS_DEPLOYMENT_TARGET = 26.0;
+				WATCHOS_DEPLOYMENT_TARGET = 11.6;
 			};
 			name = Debug;
 		};
@@ -748,7 +791,7 @@
 				TARGETED_DEVICE_FAMILY = 4;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/OvloWatch.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/OvloWatch";
 				VALIDATE_PRODUCT = YES;
-				WATCHOS_DEPLOYMENT_TARGET = 26.0;
+				WATCHOS_DEPLOYMENT_TARGET = 11.6;
 			};
 			name = Release;
 		};

--- a/OvloPhone/Info.plist
+++ b/OvloPhone/Info.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>UIBackgroundModes</key>
+	<array/>
+</dict>
+</plist>

--- a/OvloWatch/Domain/ExtendedRuntimeController.swift
+++ b/OvloWatch/Domain/ExtendedRuntimeController.swift
@@ -1,0 +1,251 @@
+import Foundation
+import os
+#if os(watchOS)
+import WatchKit
+#endif
+
+private let logger = Logger(subsystem: "com.ovlo.watch", category: "ExtendedRuntime")
+
+/// State of the extended runtime session.
+public enum ExtendedRuntimeState: Sendable, Equatable {
+    case inactive
+    case starting
+    case running
+    case expiring
+    case expired
+    case invalid
+}
+
+/// Protocol for managing extended runtime sessions to enable background execution.
+///
+/// This protocol abstracts WKExtendedRuntimeSession to enable dependency injection
+/// and testability. Implementations allow breathing sessions to continue running
+/// when the watch screen dims.
+public protocol ExtendedRuntimeControllerProtocol: Sendable {
+    /// Current state of the extended runtime session.
+    var state: ExtendedRuntimeState { get async }
+
+    /// Stream of state changes for observation.
+    var stateStream: AsyncStream<ExtendedRuntimeState> { get }
+
+    /// Starts an extended runtime session for mindfulness/breathing.
+    /// Call when a breathing session begins.
+    func startSession() async
+
+    /// Invalidates the extended runtime session.
+    /// Call when a breathing session ends or is stopped.
+    func invalidateSession() async
+}
+
+#if os(watchOS)
+/// Production implementation using WKExtendedRuntimeSession.
+///
+/// Uses the mindfulness session type which is designed for meditation
+/// and breathing apps. The system may reclaim execution time after ~30 minutes.
+public final class ExtendedRuntimeController: NSObject, ExtendedRuntimeControllerProtocol, @unchecked Sendable {
+    private var session: WKExtendedRuntimeSession?
+    private var currentState: ExtendedRuntimeState = .inactive
+    private let lock = NSLock()
+
+    private let stateContinuation: AsyncStream<ExtendedRuntimeState>.Continuation
+    public let stateStream: AsyncStream<ExtendedRuntimeState>
+
+    public override init() {
+        var continuation: AsyncStream<ExtendedRuntimeState>.Continuation!
+        self.stateStream = AsyncStream { continuation = $0 }
+        self.stateContinuation = continuation
+
+        super.init()
+    }
+
+    public var state: ExtendedRuntimeState {
+        lock.withLock { currentState }
+    }
+
+    public func startSession() async {
+        await MainActor.run {
+            lock.withLock {
+                // Invalidate any existing session first
+                session?.invalidate()
+
+                let newSession = WKExtendedRuntimeSession()
+                newSession.delegate = self
+                session = newSession
+
+                updateStateLocked(.starting)
+                newSession.start()
+                logger.info("Extended runtime session started")
+            }
+        }
+    }
+
+    public func invalidateSession() async {
+        await MainActor.run {
+            lock.withLock {
+                guard let currentSession = session else {
+                    logger.debug("No session to invalidate")
+                    return
+                }
+
+                // Only invalidate if the session is in a running state
+                // Avoids "Session not running" errors when session already ended
+                if currentSession.state == .running || currentSession.state == .scheduled {
+                    currentSession.invalidate()
+                    logger.info("Extended runtime session invalidated")
+                } else {
+                    logger.debug("Session already ended (state: \(String(describing: currentSession.state))), skipping invalidate")
+                }
+
+                session = nil
+                updateStateLocked(.inactive)
+            }
+        }
+    }
+
+    private func updateStateLocked(_ newState: ExtendedRuntimeState) {
+        currentState = newState
+        stateContinuation.yield(newState)
+    }
+
+    private func updateState(_ newState: ExtendedRuntimeState) {
+        lock.withLock {
+            updateStateLocked(newState)
+        }
+    }
+
+    deinit {
+        stateContinuation.finish()
+    }
+}
+
+// MARK: - WKExtendedRuntimeSessionDelegate
+extension ExtendedRuntimeController: WKExtendedRuntimeSessionDelegate {
+    public func extendedRuntimeSessionDidStart(
+        _ extendedRuntimeSession: WKExtendedRuntimeSession
+    ) {
+        updateState(.running)
+        logger.info("Extended runtime session is now running")
+    }
+
+    public func extendedRuntimeSessionWillExpire(
+        _ extendedRuntimeSession: WKExtendedRuntimeSession
+    ) {
+        // Session is about to expire (system reclaiming execution time)
+        // Typically ~30 seconds warning before expiration
+        updateState(.expiring)
+        logger.warning("Extended runtime session will expire soon")
+    }
+
+    public func extendedRuntimeSession(
+        _ extendedRuntimeSession: WKExtendedRuntimeSession,
+        didInvalidateWith reason: WKExtendedRuntimeSessionInvalidationReason,
+        error: Error?
+    ) {
+        // Check if this was a normal invalidation (no error) or an unexpected one
+        let newState: ExtendedRuntimeState
+        if error == nil {
+            newState = .inactive
+        } else {
+            newState = .invalid
+        }
+
+        if let error = error {
+            logger.error("Extended runtime session invalidated with error: \(error.localizedDescription)")
+        } else {
+            logger.info("Extended runtime session invalidated with reason: \(String(describing: reason))")
+        }
+
+        updateState(newState)
+    }
+}
+#endif
+
+/// Mock extended runtime controller for testing.
+///
+/// Records all session lifecycle calls and allows tests to simulate
+/// various runtime states including expiration scenarios.
+public actor MockExtendedRuntimeController: ExtendedRuntimeControllerProtocol {
+    // MARK: - Recorded State
+
+    /// Number of times startSession() was called.
+    public private(set) var startSessionCallCount = 0
+
+    /// Number of times invalidateSession() was called.
+    public private(set) var invalidateSessionCallCount = 0
+
+    /// Whether a session is currently "active" (started but not invalidated).
+    public private(set) var isSessionActive = false
+
+    // MARK: - State
+
+    private var currentState: ExtendedRuntimeState = .inactive
+    private let stateContinuation: AsyncStream<ExtendedRuntimeState>.Continuation
+    public let stateStream: AsyncStream<ExtendedRuntimeState>
+
+    // MARK: - Configuration
+
+    /// When true, startSession() will automatically transition to .running.
+    public var autoTransitionToRunning = true
+
+    public init() {
+        var continuation: AsyncStream<ExtendedRuntimeState>.Continuation!
+        self.stateStream = AsyncStream { continuation = $0 }
+        self.stateContinuation = continuation
+    }
+
+    // MARK: - ExtendedRuntimeControllerProtocol
+
+    public var state: ExtendedRuntimeState {
+        currentState
+    }
+
+    public func startSession() async {
+        startSessionCallCount += 1
+        isSessionActive = true
+
+        updateState(.starting)
+
+        if autoTransitionToRunning {
+            updateState(.running)
+        }
+    }
+
+    public func invalidateSession() async {
+        invalidateSessionCallCount += 1
+        isSessionActive = false
+        updateState(.inactive)
+    }
+
+    // MARK: - Test Helpers
+
+    /// Simulates the session expiring (system reclaiming execution time).
+    public func simulateExpiring() {
+        updateState(.expiring)
+    }
+
+    /// Simulates the session fully expired.
+    public func simulateExpired() {
+        isSessionActive = false
+        updateState(.expired)
+    }
+
+    /// Simulates an invalid session (e.g., authorization failure).
+    public func simulateInvalid() {
+        isSessionActive = false
+        updateState(.invalid)
+    }
+
+    /// Resets all recorded state.
+    public func reset() {
+        startSessionCallCount = 0
+        invalidateSessionCallCount = 0
+        isSessionActive = false
+        currentState = .inactive
+        autoTransitionToRunning = true
+    }
+
+    private func updateState(_ newState: ExtendedRuntimeState) {
+        currentState = newState
+        stateContinuation.yield(newState)
+    }
+}

--- a/OvloWatch/Info.plist
+++ b/OvloWatch/Info.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>UIBackgroundModes</key>
+	<array/>
+	<key>WKBackgroundModes</key>
+	<array>
+		<string>self-care</string>
+	</array>
+</dict>
+</plist>

--- a/OvloWatch/OvloApp.swift
+++ b/OvloWatch/OvloApp.swift
@@ -11,9 +11,15 @@ struct OvloWatchApp: App {
     init() {
         let connectivity = WatchConnectivityManager()
         let engine = BreathingEngine()
+        #if os(watchOS)
+        let extendedRuntimeController = ExtendedRuntimeController()
+        #else
+        let extendedRuntimeController: ExtendedRuntimeControllerProtocol? = nil
+        #endif
         self.viewModel = BreathingViewModel(
             engine: engine,
-            connectivity: connectivity
+            connectivity: connectivity,
+            extendedRuntimeController: extendedRuntimeController
         )
 
         // Activate connectivity on launch

--- a/OvloWatchTests/ExtendedRuntimeTests.swift
+++ b/OvloWatchTests/ExtendedRuntimeTests.swift
@@ -1,0 +1,249 @@
+import XCTest
+@testable import OvloWatch
+
+/// Tests for extended runtime session management.
+///
+/// These tests validate that breathing sessions continue running when the watch screen dims:
+/// - Sessions request background execution time when started
+/// - Sessions release background execution when stopped or completed
+/// - Users can still breathe without watching the screen
+/// - Haptic feedback continues even with screen dimmed
+@MainActor
+final class ExtendedRuntimeTests: XCTestCase {
+    private var viewModel: BreathingViewModel!
+    private var engine: BreathingEngine!
+    private var testClock: TestClock!
+    private var mockHaptics: MockHapticController!
+    private var mockConnectivity: MockWatchConnectivity!
+    private var mockRuntimeController: MockExtendedRuntimeController!
+
+    // MARK: - Constants
+
+    private let stepsPerPhase = 60
+    private var stepsPerCycle: Int { stepsPerPhase * 2 }
+
+    // MARK: - Setup & Teardown
+
+    override func setUp() async throws {
+        testClock = TestClock()
+        mockHaptics = MockHapticController()
+        mockConnectivity = MockWatchConnectivity()
+        mockRuntimeController = MockExtendedRuntimeController()
+
+        engine = BreathingEngine(
+            clock: testClock,
+            hapticController: mockHaptics
+        )
+
+        viewModel = BreathingViewModel(
+            engine: engine,
+            connectivity: mockConnectivity,
+            extendedRuntimeController: mockRuntimeController
+        )
+    }
+
+    override func tearDown() async throws {
+        await engine.stop()
+        viewModel = nil
+        engine = nil
+        testClock = nil
+        mockHaptics = nil
+        mockConnectivity = nil
+        mockRuntimeController = nil
+    }
+
+    // MARK: - Test Helpers
+
+    /// Advances the test clock by a specified number of steps, allowing the engine to progress.
+    private func advanceEngine(steps: Int) async throws {
+        for _ in 0..<steps {
+            await testClock.advance()
+            try await Task.sleep(for: .milliseconds(1))
+        }
+    }
+
+    /// Simulates iOS sending a start command to the watch.
+    private func sendIOSStartCommand(durationMinutes: Int) async throws {
+        let message: [String: Any] = [
+            ConnectivityMessageKey.command: ConnectivityCommand.start.rawValue,
+            ConnectivityMessageKey.duration: durationMinutes
+        ]
+        _ = mockConnectivity.simulateReceivingMessage(message)
+        try await Task.sleep(for: .milliseconds(50))
+    }
+
+    /// Simulates iOS sending a stop command to the watch.
+    private func sendIOSStopCommand() async throws {
+        let message: [String: Any] = [
+            ConnectivityMessageKey.command: ConnectivityCommand.stop.rawValue
+        ]
+        _ = mockConnectivity.simulateReceivingMessage(message)
+        try await Task.sleep(for: .milliseconds(50))
+    }
+
+    // MARK: - Background Execution When Session Starts
+
+    func testSessionRequestsBackgroundExecutionOnStart() async throws {
+        // === GIVEN: User is on start screen ===
+        let initialCount = await mockRuntimeController.startSessionCallCount
+        XCTAssertEqual(initialCount, 0, "No background execution requested yet")
+
+        // === WHEN: User starts a breathing session ===
+        await viewModel.startLocalSession()
+        try await Task.sleep(for: .milliseconds(10))
+
+        // === THEN: App requests permission to run with screen dimmed ===
+        let finalCount = await mockRuntimeController.startSessionCallCount
+        XCTAssertEqual(finalCount, 1, "Should request background execution when session starts")
+
+        let isActive = await mockRuntimeController.isSessionActive
+        XCTAssertTrue(isActive, "Background execution should be active")
+    }
+
+    func testIOSStartedSessionRequestsBackgroundExecution() async throws {
+        // === GIVEN: Watch is idle ===
+        let initialCount = await mockRuntimeController.startSessionCallCount
+        XCTAssertEqual(initialCount, 0)
+
+        // === WHEN: iOS sends start command ===
+        try await sendIOSStartCommand(durationMinutes: 5)
+
+        // === THEN: Watch requests background execution ===
+        let count = await mockRuntimeController.startSessionCallCount
+        XCTAssertEqual(count, 1, "iOS-started sessions should also request background execution")
+    }
+
+    // MARK: - Background Execution Released When Session Ends
+
+    func testUserStoppingSessionReleasesBackgroundExecution() async throws {
+        // === GIVEN: User is mid-session ===
+        await viewModel.startLocalSession()
+        try await Task.sleep(for: .milliseconds(10))
+
+        // === WHEN: User stops the session ===
+        await viewModel.stopSession()
+        try await Task.sleep(for: .milliseconds(10))
+
+        // === THEN: Background execution is released to save battery ===
+        let invalidateCount = await mockRuntimeController.invalidateSessionCallCount
+        XCTAssertEqual(invalidateCount, 1, "Should release background execution when user stops")
+
+        let isActive = await mockRuntimeController.isSessionActive
+        XCTAssertFalse(isActive, "Background execution should no longer be active")
+    }
+
+    func testCompletedSessionReleasesBackgroundExecution() async throws {
+        // === GIVEN: User starts a short 1-minute session ===
+        viewModel.selectedDuration = 1
+        await viewModel.startLocalSession()
+        try await Task.sleep(for: .milliseconds(10))
+
+        // === WHEN: Session completes naturally ===
+        let totalSteps = stepsPerCycle * 5  // 1 min = 5 cycles
+        try await advanceEngine(steps: totalSteps)
+        try await Task.sleep(for: .milliseconds(50))
+
+        // === THEN: Session completed successfully ===
+        XCTAssertEqual(viewModel.currentState, .completed, "Session should complete")
+
+        // === AND: Background execution is released ===
+        let invalidateCount = await mockRuntimeController.invalidateSessionCallCount
+        XCTAssertEqual(invalidateCount, 1, "Should release background execution when session completes")
+
+        let isActive = await mockRuntimeController.isSessionActive
+        XCTAssertFalse(isActive, "Background execution should no longer be active")
+    }
+
+    func testSwipeToCompleteReleasesBackgroundExecution() async throws {
+        // === GIVEN: User is mid-session ===
+        await viewModel.startLocalSession()
+        try await Task.sleep(for: .milliseconds(10))
+        try await advanceEngine(steps: 30)
+
+        // === WHEN: User swipes up to complete early ===
+        await viewModel.completeSessionEarly()
+        try await Task.sleep(for: .milliseconds(10))
+
+        // === THEN: Background execution is released ===
+        let invalidateCount = await mockRuntimeController.invalidateSessionCallCount
+        XCTAssertEqual(invalidateCount, 1, "Early completion should release background execution")
+
+        let isActive = await mockRuntimeController.isSessionActive
+        XCTAssertFalse(isActive)
+    }
+
+    func testIOSStopCommandReleasesBackgroundExecution() async throws {
+        // === GIVEN: Session started from iOS ===
+        try await sendIOSStartCommand(durationMinutes: 5)
+        try await advanceEngine(steps: 10)
+
+        // === WHEN: iOS sends stop command ===
+        try await sendIOSStopCommand()
+
+        // === THEN: Background execution is released ===
+        let invalidateCount = await mockRuntimeController.invalidateSessionCallCount
+        XCTAssertEqual(invalidateCount, 1, "iOS stop should release background execution")
+    }
+
+    // MARK: - Multiple Sessions
+
+    func testRestartingSessionRequestsNewBackgroundExecution() async throws {
+        // === GIVEN: User completes first session ===
+        await viewModel.startLocalSession()
+        try await Task.sleep(for: .milliseconds(10))
+        await viewModel.stopSession()
+        try await Task.sleep(for: .milliseconds(10))
+
+        // === WHEN: User starts a new session ===
+        await viewModel.startLocalSession()
+        try await Task.sleep(for: .milliseconds(10))
+
+        // === THEN: New background execution is requested ===
+        let startCount = await mockRuntimeController.startSessionCallCount
+        XCTAssertEqual(startCount, 2, "Each session start should request background execution")
+
+        // === AND: Previous session's execution was properly released ===
+        let invalidateCount = await mockRuntimeController.invalidateSessionCallCount
+        XCTAssertEqual(invalidateCount, 1, "First session should have released execution")
+    }
+
+    // MARK: - Graceful Degradation
+
+    func testAppWorksWithoutBackgroundExecutionController() async throws {
+        // === GIVEN: ViewModel created without extended runtime controller ===
+        // (This could happen on older OS versions or if entitlements are missing)
+        let viewModelWithoutRuntime = BreathingViewModel(
+            engine: engine,
+            connectivity: mockConnectivity
+            // No extendedRuntimeController provided
+        )
+
+        // === WHEN: User starts a session ===
+        await viewModelWithoutRuntime.startLocalSession()
+        try await Task.sleep(for: .milliseconds(10))
+        try await advanceEngine(steps: 5)
+
+        // === THEN: Session works normally (no crash) ===
+        XCTAssertTrue(
+            viewModelWithoutRuntime.currentState.isActive,
+            "Session should work even without background execution support"
+        )
+
+        // === AND: Mock was never called (verifies isolation) ===
+        let startCount = await mockRuntimeController.startSessionCallCount
+        XCTAssertEqual(startCount, 0, "Should not affect other view models")
+    }
+
+    func testBackgroundExecutionTransitionsToRunningState() async throws {
+        // === GIVEN: Fresh runtime controller ===
+        await mockRuntimeController.reset()
+
+        // === WHEN: User starts session ===
+        await viewModel.startLocalSession()
+        try await Task.sleep(for: .milliseconds(10))
+
+        // === THEN: Runtime state is running (ready for screen to dim) ===
+        let state = await mockRuntimeController.state
+        XCTAssertEqual(state, .running, "Background execution should be in running state")
+    }
+}


### PR DESCRIPTION
## Summary

Adds `WKExtendedRuntimeSession` support to keep breathing exercises running when the watch screen dims. Uses the `self-care` background mode entitlement for mindfulness apps. The `BreathingViewModel` now manages session lifecycle through an injected `ExtendedRuntimeControllerProtocol` for testability.

## Changes

- New `ExtendedRuntimeController` with protocol abstraction for background execution
- `BreathingViewModel` starts/stops extended runtime with session lifecycle
- Info.plist files for entitlement configuration
- Deployment target adjustments (watchOS 11.6, iOS 18.6)
- Comprehensive test suite for runtime session scenarios